### PR TITLE
Added foreground service permission to library manifest

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.yariksoffice.venom">
 
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/venom/src/main/AndroidManifest.xml
+++ b/venom/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.yariksoffice.venom">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application>
         <activity android:name=".DeathActivity" />
         <service android:name=".VenomService" />


### PR DESCRIPTION
Just moved the required permission from sample app to library manifest, so merger tool can do its job for all venom consumers.