### PR TITLE
Replace appcompat by androidX core

### DIFF
--- a/venom/build.gradle
+++ b/venom/build.gradle
@@ -28,7 +28,7 @@ apply from: '../common-android.gradle'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "androidx.core:core:1.2.0"
     testImplementation "junit:junit:4.13"
     testImplementation "io.mockk:mockk:1.9.3"
 }


### PR DESCRIPTION
There is no need to implement `appcompat` as Venom uses only `NotificationCompat` and `ContextCompat`classes which belong to the core library.