### PR TITLE
Start Foreground Service from Background on API 26+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         ktlintGradleVersion = "9.2.1"
 
         appCompatVersion = "1.1.0"
-        androidXCoreVersion = "1.2.0"
+        androidXCoreVersion = "1.3.0"
         constraintLayoutVersion = "1.1.3"
 
         junitVersion = "4.13"

--- a/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
+++ b/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
@@ -8,7 +8,7 @@ internal class ServiceDelegate(private val context: Context) {
 
     fun startService() {
         if (!isServiceRunning()) {
-            context.startService(Intent(context, VenomService::class.java))
+            context.startForegroundService(Intent(context, VenomService::class.java))
         }
     }
 

--- a/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
+++ b/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
@@ -1,6 +1,7 @@
 package com.github.venom.service
 
 import android.app.ActivityManager
+import android.os.Build
 import android.content.Context
 import android.content.Intent
 

--- a/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
+++ b/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
@@ -1,19 +1,16 @@
 package com.github.venom.service
 
+
 import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
-import android.os.Build
+import androidx.core.content.ContextCompat
 
 internal class ServiceDelegate(private val context: Context) {
 
     fun startService() {
         if (!isServiceRunning()) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(Intent(context, VenomService::class.java))
-            } else {
-                context.startService(Intent(context, VenomService::class.java))
-            }
+            ContextCompat.startForegroundService(context, Intent(context, VenomService::class.java))
         }
     }
 

--- a/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
+++ b/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
@@ -8,7 +8,11 @@ internal class ServiceDelegate(private val context: Context) {
 
     fun startService() {
         if (!isServiceRunning()) {
-            context.startForegroundService(Intent(context, VenomService::class.java))
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(Intent(context, VenomService::class.java))
+            } else {
+                context.startService(Intent(context, VenomService::class.java))
+            }
         }
     }
 

--- a/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
+++ b/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
@@ -1,6 +1,5 @@
 package com.github.venom.service
 
-
 import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent

--- a/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
+++ b/venom/src/main/java/com/github/venom/service/ServiceDelegate.kt
@@ -1,9 +1,9 @@
 package com.github.venom.service
 
 import android.app.ActivityManager
-import android.os.Build
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 
 internal class ServiceDelegate(private val context: Context) {
 

--- a/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
+++ b/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
@@ -4,6 +4,7 @@ import android.app.ActivityManager
 import android.app.ActivityManager.RunningServiceInfo
 import android.content.Context
 import android.content.Context.ACTIVITY_SERVICE
+import android.os.Build
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
+++ b/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
@@ -28,7 +28,13 @@ class ServiceDelegateTest {
         setRunningState(false)
         delegate.startService()
         // it's not possible to verify the Intent unfortunately
-        verify { context.startForegroundService(any()) }
+        verify {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(any())
+            } else {
+                context.startService(any())
+            }
+        }
     }
 
     @Test
@@ -36,7 +42,13 @@ class ServiceDelegateTest {
         setRunningState(true)
         delegate.startService()
 
-        verify(exactly = 0) { context.startForegroundService(any()) }
+        verify(exactly = 0) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(any())
+            } else {
+                context.startService(any())
+            }
+        }
     }
 
     @Test

--- a/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
+++ b/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
@@ -7,6 +7,7 @@ import android.content.Context.ACTIVITY_SERVICE
 import androidx.core.content.ContextCompat
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -27,17 +28,20 @@ class ServiceDelegateTest {
     @Test
     fun startService_startServiceIfNotRunning() {
         setRunningState(false)
-        delegate.startService()
-        // it's not possible to verify the Intent unfortunately
-        verify { ContextCompat.startForegroundService(any(), any()) }
+        mockkStatic(androidx.core.content.ContextCompat::class) {
+            delegate.startService()
+            // it's not possible to verify the Intent unfortunately
+            verify { ContextCompat.startForegroundService(any(), any()) }
+        }
     }
 
     @Test
     fun startService_dontStartServiceIfAlreadyRunning() {
         setRunningState(true)
-        delegate.startService()
-
-        verify(exactly = 0) { ContextCompat.startForegroundService(any(), any()) }
+        mockkStatic(androidx.core.content.ContextCompat::class) {
+            delegate.startService()
+            verify(exactly = 0) { ContextCompat.startForegroundService(any(), any()) }
+        }
     }
 
     @Test

--- a/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
+++ b/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
@@ -4,7 +4,7 @@ import android.app.ActivityManager
 import android.app.ActivityManager.RunningServiceInfo
 import android.content.Context
 import android.content.Context.ACTIVITY_SERVICE
-import android.os.Build
+import androidx.core.content.ContextCompat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -29,13 +29,7 @@ class ServiceDelegateTest {
         setRunningState(false)
         delegate.startService()
         // it's not possible to verify the Intent unfortunately
-        verify {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(any())
-            } else {
-                context.startService(any())
-            }
-        }
+        verify { ContextCompat.startForegroundService(any(), any()) }
     }
 
     @Test
@@ -43,13 +37,7 @@ class ServiceDelegateTest {
         setRunningState(true)
         delegate.startService()
 
-        verify(exactly = 0) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(any())
-            } else {
-                context.startService(any())
-            }
-        }
+        verify(exactly = 0) { ContextCompat.startForegroundService(any(), any()) }
     }
 
     @Test

--- a/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
+++ b/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
@@ -28,7 +28,8 @@ class ServiceDelegateTest {
     @Test
     fun startService_startServiceIfNotRunning() {
         setRunningState(false)
-        mockkStatic(androidx.core.content.ContextCompat::class) {
+
+        mockkStatic(ContextCompat::class) {
             delegate.startService()
             // it's not possible to verify the Intent unfortunately
             verify { ContextCompat.startForegroundService(any(), any()) }
@@ -38,7 +39,8 @@ class ServiceDelegateTest {
     @Test
     fun startService_dontStartServiceIfAlreadyRunning() {
         setRunningState(true)
-        mockkStatic(androidx.core.content.ContextCompat::class) {
+
+        mockkStatic(ContextCompat::class) {
             delegate.startService()
             verify(exactly = 0) { ContextCompat.startForegroundService(any(), any()) }
         }

--- a/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
+++ b/venom/src/test/java/com/github/venom/service/ServiceDelegateTest.kt
@@ -28,7 +28,7 @@ class ServiceDelegateTest {
         setRunningState(false)
         delegate.startService()
         // it's not possible to verify the Intent unfortunately
-        verify { context.startService(any()) }
+        verify { context.startForegroundService(any()) }
     }
 
     @Test
@@ -36,7 +36,7 @@ class ServiceDelegateTest {
         setRunningState(true)
         delegate.startService()
 
-        verify(exactly = 0) { context.startService(any()) }
+        verify(exactly = 0) { context.startForegroundService(any()) }
     }
 
     @Test


### PR DESCRIPTION
Replace startService with startForegroundService.
Since `VenomService` is a foreground `Service`, it's supposed to be started with `startForegroundService`.
This prevent such RuntimeError:

```
java.lang.IllegalStateException: Not allowed to start service Intent { cmp=/com.github.venom.service.VenomService }: app is in background uid UidRecord{d72b26b u0a311 TRNB idle change:uncached procs:2 proclist:12656,13757, seq(0,0,0)}
        at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1687)
        at android.app.ContextImpl.startService(ContextImpl.java:1632)
        at android.content.ContextWrapper.startService(ContextWrapper.java:683)
        at com.github.venom.service.ServiceDelegate.startService(ServiceDelegate.kt:11)
        at com.github.venom.Venom.start(Venom.kt:61)
        at com.github.venom.Venom.initialize(Venom.kt:52)
        at com.github.venom.Venom.initialize$default(Venom.kt:49)
```