### PR TITLE
Run AGP migration to use namespace and testNamespace

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,9 +28,7 @@ apply from: '../static-analysis.gradle'
 apply from: '../common-android.gradle'
 
 android {
-    defaultConfig {
-        applicationId "com.github.venom.sample"
-    }
+    namespace 'com.github.venom.sample'
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -28,6 +28,7 @@ apply from: '../static-analysis.gradle'
 apply from: '../common-android.gradle'
 
 android {
+    defaultConfig.applicationId 'com.github.venom.sample'
     namespace 'com.github.venom.sample'
 }
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.github.venom.sample">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 

--- a/venom-no-op/build.gradle
+++ b/venom-no-op/build.gradle
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 apply from: '../common-android.gradle'
 apply from: '../static-analysis.gradle'
 
+android.namespace 'com.github.venom'
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }

--- a/venom-no-op/src/main/AndroidManifest.xml
+++ b/venom-no-op/src/main/AndroidManifest.xml
@@ -22,5 +22,4 @@
   ~ SOFTWARE.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.venom" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/venom/build.gradle
+++ b/venom/build.gradle
@@ -27,6 +27,11 @@ apply plugin: 'kotlin-android'
 apply from: '../static-analysis.gradle'
 apply from: '../common-android.gradle'
 
+android {
+    namespace 'com.github.venom'
+    testNamespace 'com.github.venom.test'
+}
+
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$androidXCoreVersion"

--- a/venom/src/androidTest/AndroidManifest.xml
+++ b/venom/src/androidTest/AndroidManifest.xml
@@ -23,8 +23,7 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.github.venom.test">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="android_libs.ub_uiautomator" />
 

--- a/venom/src/main/AndroidManifest.xml
+++ b/venom/src/main/AndroidManifest.xml
@@ -22,8 +22,7 @@
   ~ SOFTWARE.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.venom">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 


### PR DESCRIPTION
```
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```