### PR TITLE
Added foregroundServiceType property to VenomService

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ buildscript {
         uiAutomatorVersion = "2.2.0"
 
         minSdkVersion = 14
-        targetSdkVersion = 33
-        compileSdkVersion = 33
+        targetSdkVersion = 34
+        compileSdkVersion = 34
         versionName = "0.6.1"
     }
     repositories {

--- a/venom/src/main/AndroidManifest.xml
+++ b/venom/src/main/AndroidManifest.xml
@@ -30,7 +30,13 @@
         <activity
             android:name=".DeathActivity"
             android:theme="@style/VenomDeath" />
-        <service android:name=".service.VenomService" />
+        <service 
+            android:name=".service.VenomService" 
+            android:foregroundServiceType="specialUse">
+            <property 
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE" 
+                android:value="KillProcess"/>
+        </service>
     </application>
 
 </manifest>

--- a/venom/src/main/AndroidManifest.xml
+++ b/venom/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
 
     <application>
         <activity


### PR DESCRIPTION
This is a fix for an issue https://github.com/YarikSOffice/venom/issues/50

### The problem

In Android 14 on init of Venom Service system throws an exception:
java.lang.RuntimeException: Unable to create service com.github.venom.service.VenomService: android.app.MissingForegroundServiceTypeException: Starting FGS without a type  ...  targetSDK=34

https://developer.android.com/about/versions/14/changes/fgs-types-required
If your app targets Android 14, it must specify appropriate foreground service types.

Like in example

      <service
          android:name=".MyMediaPlaybackService"
          android:foregroundServiceType="mediaPlayback"
          android:exported="false">
      </service>

### The solution

Since Venom service is not an ordinary one, the type for the foreground service is `specialUse`
`android:foregroundServiceType="specialUse"`

Special use service requires a property explaining its purpose for review team. I just used KillProcess as self explanatory.
```
<property 
                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE" 
                android:value="KillProcess"/>
```

Also special use service requires permission
```
    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
```

